### PR TITLE
Fix wallpaper rendering to respect configured timezonefix: respect configured timezone in wallpaper rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Deploy targets:
   - `/samples`
 - Per-view settings with shareable embed URLs
 - Direct PageShot wallpaper URLs for Shortcuts and lock-screen automation
+- Optional timezone override for shared views and wallpapers
 - Theme-aware homepage and embed-friendly views
 - GitHub Pages and Vercel deployment support
 
@@ -46,6 +47,20 @@ npm run dev
 ## Documentation
 
 See [docs/README.md](./docs/README.md) for full documentation.
+
+## Timezone Override
+
+Views can optionally pin their clock to a UTC offset by setting `timezone` in the query string or gear panel.
+
+Example:
+
+```text
+/view/countdown?timezone=UTC+4
+```
+
+- Accepted format: `UTC±H` with optional minutes such as `UTC+5:30`
+- Leave it blank to keep the runtime's local/system time
+- Invalid values fall back to `UTC+0`
 
 ## Contributing
 

--- a/docs/DEVELOPER.md
+++ b/docs/DEVELOPER.md
@@ -61,6 +61,7 @@ npm install
 - appearance controls are managed from the view gear
 - copied embed links preserve the active view configuration
 - copied wallpaper URLs preserve the active view configuration plus requested image size
+- view time can be pinned with `timezone=UTC+4` or another UTC offset
 - embed-specific shell flags:
   - `embed=true` removes shell chrome
   - `logo=false` hides the embed corner logo

--- a/docs/PROJECT.md
+++ b/docs/PROJECT.md
@@ -74,6 +74,7 @@ Examples:
 - View appearance is query-driven for sharing and embed links
 - View settings are also persisted locally via cookies
 - When a view is opened, the site theme follows that view unless an explicit `theme` query param is present
+- Views can optionally override runtime time with a `timezone` setting such as `UTC+4`
 
 ## View Notes
 
@@ -81,7 +82,7 @@ Examples:
 
 - Live countdown to the next January 1
 - Responsive multi-unit layout
-- Settings include display mode, frame, and labels
+- Settings include display mode, timezone, frame, and labels
 
 ### Dots
 
@@ -117,7 +118,13 @@ Examples:
   - theme
   - primary and secondary colors
   - text tone
+  - optional timezone override
   - requested image width and height
+- Accepted timezone format:
+  - `UTC±H`
+  - optional minutes such as `UTC+5:30`
+- Blank timezone uses runtime local time
+- Invalid timezone values fall back to `UTC+0`
 - Intended use:
   - iPhone Shortcuts
   - direct image fetching

--- a/src/components/ViewSettingsGear.jsx
+++ b/src/components/ViewSettingsGear.jsx
@@ -57,6 +57,57 @@ const renderNumberControl = ({ control, value, viewId, updateViewSetting }) => {
   );
 };
 
+const TextSettingInput = ({ control, value, viewId, updateViewSetting }) => {
+  const [draftValue, setDraftValue] = useState(value ?? '');
+
+  const commitValue = () => {
+    updateViewSetting(viewId, control.key, draftValue);
+  };
+
+  return (
+    <input
+      type="text"
+      value={draftValue}
+      placeholder={control.placeholder ?? ''}
+      onChange={(event) => setDraftValue(event.target.value)}
+      onBlur={commitValue}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter') {
+          event.currentTarget.blur();
+        }
+
+        if (event.key === 'Escape') {
+          setDraftValue(value ?? '');
+          event.currentTarget.blur();
+        }
+      }}
+      className="w-full rounded-2xl border border-black/10 bg-transparent px-4 py-3 text-sm text-black outline-none transition-colors focus:border-black/25 dark:border-white/10 dark:text-white dark:focus:border-white/25"
+    />
+  );
+};
+
+const renderTextControl = ({ control, value, viewId, updateViewSetting }) => {
+  return (
+    <div key={control.key}>
+      <div className="mb-2 flex items-center justify-between gap-3">
+        <p className="text-[0.65rem] uppercase tracking-[0.24em] text-black/40 dark:text-white/40">
+          {control.label}
+        </p>
+        <span className="shrink-0 text-xs text-black/45 dark:text-white/45">
+          {value || 'System'}
+        </span>
+      </div>
+      <TextSettingInput
+        key={`${control.key}-${value ?? ''}`}
+        control={control}
+        value={value}
+        viewId={viewId}
+        updateViewSetting={updateViewSetting}
+      />
+    </div>
+  );
+};
+
 const getSpacingHelperValue = (state, key) => {
   if (!state) {
     return '';
@@ -330,6 +381,10 @@ const renderControl = ({ control, viewId, viewState, updateViewSetting }) => {
 
   if (control.type === 'number') {
     return renderNumberControl({ control, value, viewId, updateViewSetting });
+  }
+
+  if (control.type === 'text') {
+    return renderTextControl({ control, value, viewId, updateViewSetting });
   }
 
   if (control.type === 'spacing-helper') {

--- a/src/components/home/HomepageSections.jsx
+++ b/src/components/home/HomepageSections.jsx
@@ -95,7 +95,7 @@ const getGalleryPreviewUrl = ({ id, viewId, viewState, theme }) => {
   params.set('_gallery', id);
 
   Object.entries(viewState).forEach(([key, value]) => {
-    if (value === undefined || value === null || typeof value === 'object') {
+    if (value === undefined || value === null || value === '' || typeof value === 'object') {
       return;
     }
 

--- a/src/components/views/AllView.jsx
+++ b/src/components/views/AllView.jsx
@@ -184,6 +184,7 @@ const AllView = ({
   showDays = true,
   showPercentBox = true,
   showPerimeter = true,
+  timezone = '',
   shape = 'circle',
   triangleMode = 'alternating',
   triangleAngle = 0,
@@ -211,8 +212,8 @@ const AllView = ({
 }) => {
   const outerRef = useRef(null);
   const [outerSize, setOuterSize] = useState({ width: 0, height: 0 });
-  const countdown = useCountdown();
-  const progress = useYearProgress(decimals);
+  const countdown = useCountdown(timezone);
+  const progress = useYearProgress(decimals, timezone);
   const totalDots = dotsMode === 'custom' ? dotsCount : undefined;
   const completedDots =
     dotsMode === 'custom' ? Math.round((progress.percentage / 100) * Math.max(1, dotsCount)) : undefined;
@@ -430,6 +431,7 @@ const AllView = ({
             shape={shape}
             triangleMode={triangleMode}
             triangleAngle={triangleAngle}
+            timezone={timezone}
             gapX={gapX}
             gapY={gapY}
             spaceTop={0}

--- a/src/components/views/CountdownView.jsx
+++ b/src/components/views/CountdownView.jsx
@@ -100,6 +100,7 @@ const CountdownView = ({
   mode = 'all',
   frame = false,
   labels = true,
+  timezone = '',
   fontSize = 1,
   spaceTop = 0,
   spaceRight = 0,
@@ -109,7 +110,7 @@ const CountdownView = ({
   alternateColor,
   textToneColor,
 }) => {
-  const countdown = useCountdown();
+  const countdown = useCountdown(timezone);
   const { containerRef, tokens } = useResponsiveCountdown({ mode, labels });
   const spacingBase = Math.min(tokens.width, tokens.height);
   const contentPadding = {

--- a/src/components/views/DotsView.jsx
+++ b/src/components/views/DotsView.jsx
@@ -69,6 +69,7 @@ const DotsView = ({
   shape = 'circle',
   triangleMode = 'upright',
   triangleAngle = 0,
+  timezone = '',
   gapX = 0.5,
   gapY = 0.5,
   spaceTop = 0,
@@ -90,6 +91,7 @@ const DotsView = ({
     spaceLeftPercent: spaceLeft,
     totalDots,
     completedCount,
+    timezone,
   });
 
   return (

--- a/src/components/views/PieView.jsx
+++ b/src/components/views/PieView.jsx
@@ -268,6 +268,7 @@ const PieView = ({
   style = 'filled',
   fullScreen = false,
   decimals = 2,
+  timezone = '',
   spaceTop = 0,
   spaceRight = 0,
   spaceBottom = 0,
@@ -276,7 +277,7 @@ const PieView = ({
   alternateColor,
   textToneColor,
 }) => {
-  const { percentage, percentageLabel } = useYearProgress(decimals);
+  const { percentage, percentageLabel } = useYearProgress(decimals, timezone);
   const { containerRef, layout } = usePieLayout({
     shape,
     fullScreen,

--- a/src/components/views/ProgressView.jsx
+++ b/src/components/views/ProgressView.jsx
@@ -155,6 +155,7 @@ const ProgressView = ({
   mode = 'field',
   fullScreen = true,
   decimals = 2,
+  timezone = '',
   fontSize = 1,
   lineWidth = 12,
   spaceTop = 0,
@@ -165,7 +166,7 @@ const ProgressView = ({
   alternateColor,
   textToneColor,
 }) => {
-  const { percentage } = useYearProgress(decimals);
+  const { percentage } = useYearProgress(decimals, timezone);
   const { containerRef, layout } = useProgressLayout({
     mode,
     fullScreen,

--- a/src/hooks/useCountdown.js
+++ b/src/hooks/useCountdown.js
@@ -1,9 +1,8 @@
 import { useEffect, useMemo, useState } from 'react';
 
-import { SECOND, getCountdownSnapshot, getCountdownTarget } from '../lib/timeMath';
+import { SECOND, getCountdownSnapshot } from '../lib/timeMath';
 
-const useCountdown = () => {
-  const [target] = useState(() => getCountdownTarget());
+const useCountdown = (timezone) => {
   const [nowTime, setNowTime] = useState(() => Date.now());
 
   useEffect(() => {
@@ -18,10 +17,9 @@ const useCountdown = () => {
 
   return useMemo(() => {
     return {
-      ...getCountdownSnapshot(nowTime),
-      target,
+      ...getCountdownSnapshot(nowTime, timezone),
     };
-  }, [nowTime, target]);
+  }, [nowTime, timezone]);
 };
 
 export default useCountdown;

--- a/src/hooks/useDotsGrid.js
+++ b/src/hooks/useDotsGrid.js
@@ -11,6 +11,7 @@ const useDotsGrid = ({
   spaceLeftPercent,
   totalDots,
   completedCount,
+  timezone,
 }) => {
   const containerRef = useRef(null);
   const [containerSize, setContainerSize] = useState({ width: 0, height: 0 });
@@ -60,6 +61,7 @@ const useDotsGrid = ({
       spaceLeftPercent,
       totalDotsOverride: totalDots,
       completedCountOverride: completedCount,
+      timezone,
     });
 
     return {
@@ -82,6 +84,7 @@ const useDotsGrid = ({
     spaceRightPercent,
     spaceTopPercent,
     totalDots,
+    timezone,
   ]);
 };
 

--- a/src/hooks/useYearProgress.js
+++ b/src/hooks/useYearProgress.js
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from 'react';
 
 import { SECOND, getYearProgress } from '../lib/timeMath';
 
-const useYearProgress = (decimals = 2) => {
+const useYearProgress = (decimals = 2, timezone) => {
   const [nowTime, setNowTime] = useState(() => Date.now());
 
   useEffect(() => {
@@ -16,13 +16,13 @@ const useYearProgress = (decimals = 2) => {
   }, []);
 
   return useMemo(() => {
-    const progress = getYearProgress(nowTime);
+    const progress = getYearProgress(nowTime, timezone);
 
     return {
       ...progress,
       percentageLabel: `${progress.percentage.toFixed(decimals)}%`,
     };
-  }, [decimals, nowTime]);
+  }, [decimals, nowTime, timezone]);
 };
 
 export default useYearProgress;

--- a/src/lib/dotsMath.js
+++ b/src/lib/dotsMath.js
@@ -82,8 +82,9 @@ export const getDotsSnapshot = ({
   totalDotsOverride,
   completedCountOverride,
   nowTime = Date.now(),
+  timezone,
 }) => {
-  const { totalDays, currentDayIndex } = getYearMeta(nowTime);
+  const { totalDays, currentDayIndex } = getYearMeta(nowTime, timezone);
   const totalDots = Number.isFinite(totalDotsOverride)
     ? Math.max(1, Math.round(totalDotsOverride))
     : totalDays;

--- a/src/lib/timeMath.js
+++ b/src/lib/timeMath.js
@@ -2,13 +2,139 @@ export const SECOND = 1000;
 export const MINUTE = 60 * SECOND;
 export const HOUR = 60 * MINUTE;
 export const DAY = 24 * HOUR;
+export const SYSTEM_TIMEZONE = '';
+export const INVALID_TIMEZONE_FALLBACK = 'UTC+0';
+
+const MIN_TIMEZONE_OFFSET_MINUTES = -12 * 60;
+const MAX_TIMEZONE_OFFSET_MINUTES = 14 * 60;
+const TIMEZONE_PATTERN = /^UTC(?:([+-]?)(\d{1,2})(?::?(\d{2}))?)?$/i;
+
+const getNowTimeValue = (value) => {
+  if (value instanceof Date) {
+    return value.getTime();
+  }
+
+  return Number.isFinite(value) ? value : Date.now();
+};
+
+export const formatTimezoneOffset = (offsetMinutes) => {
+  if (!Number.isFinite(offsetMinutes)) {
+    return INVALID_TIMEZONE_FALLBACK;
+  }
+
+  const absoluteMinutes = Math.abs(Math.trunc(offsetMinutes));
+  const sign = offsetMinutes < 0 ? '-' : '+';
+  const hours = Math.floor(absoluteMinutes / 60);
+  const minutes = absoluteMinutes % 60;
+
+  if (minutes === 0) {
+    return `UTC${sign}${hours}`;
+  }
+
+  return `UTC${sign}${hours}:${String(minutes).padStart(2, '0')}`;
+};
+
+export const parseTimezoneOffsetMinutes = (value) => {
+  if (typeof value !== 'string') {
+    return null;
+  }
+
+  const trimmed = value.trim().toUpperCase().replace(/\s+/g, '');
+
+  if (!trimmed) {
+    return null;
+  }
+
+  const match = trimmed.match(TIMEZONE_PATTERN);
+
+  if (!match) {
+    return null;
+  }
+
+  const sign = match[1];
+  const hoursGroup = match[2];
+  const minutesGroup = match[3];
+
+  if (!hoursGroup) {
+    return 0;
+  }
+
+  const hours = Number.parseInt(hoursGroup, 10);
+  const minutes = minutesGroup ? Number.parseInt(minutesGroup, 10) : 0;
+
+  if (!Number.isInteger(hours) || !Number.isInteger(minutes) || minutes >= 60) {
+    return null;
+  }
+
+  const absoluteMinutes = hours * 60 + minutes;
+  const offsetMinutes = sign === '-' ? -absoluteMinutes : absoluteMinutes;
+
+  if (
+    offsetMinutes < MIN_TIMEZONE_OFFSET_MINUTES ||
+    offsetMinutes > MAX_TIMEZONE_OFFSET_MINUTES
+  ) {
+    return null;
+  }
+
+  return offsetMinutes;
+};
+
+export const normalizeTimezoneSetting = (value, fallback = SYSTEM_TIMEZONE) => {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+
+  if (!trimmed) {
+    return fallback;
+  }
+
+  const offsetMinutes = parseTimezoneOffsetMinutes(trimmed);
+
+  if (offsetMinutes === null) {
+    return fallback;
+  }
+
+  return formatTimezoneOffset(offsetMinutes);
+};
+
+const getResolvedTimezoneOffsetMinutes = (timezone) => {
+  if (typeof timezone !== 'string' || !timezone.trim()) {
+    return null;
+  }
+
+  const offsetMinutes = parseTimezoneOffsetMinutes(timezone);
+
+  return offsetMinutes === null ? 0 : offsetMinutes;
+};
+
+const getClockYear = (nowTime, timezoneOffsetMinutes) => {
+  if (timezoneOffsetMinutes === null) {
+    return new Date(nowTime).getFullYear();
+  }
+
+  return new Date(nowTime + timezoneOffsetMinutes * MINUTE).getUTCFullYear();
+};
+
+const getYearBoundary = (year, timezoneOffsetMinutes) => {
+  if (timezoneOffsetMinutes === null) {
+    return new Date(year, 0, 1, 0, 0, 0, 0);
+  }
+
+  return new Date(Date.UTC(year, 0, 1, 0, 0, 0, 0) - timezoneOffsetMinutes * MINUTE);
+};
 
 export const clampCountdownDiff = (targetTime, nowTime) => {
   return Math.max(0, targetTime - nowTime);
 };
 
-export const getCountdownTarget = (nowDate = new Date()) => {
-  return new Date(nowDate.getFullYear() + 1, 0, 1, 0, 0, 0, 0);
+export const getCountdownTarget = (nowTime = Date.now(), timezone = SYSTEM_TIMEZONE) => {
+  const resolvedNowTime = getNowTimeValue(nowTime);
+  const timezoneOffsetMinutes = getResolvedTimezoneOffsetMinutes(timezone);
+  const year = getClockYear(resolvedNowTime, timezoneOffsetMinutes);
+
+  return getYearBoundary(year + 1, timezoneOffsetMinutes);
 };
 
 export const getCountdownParts = (diff) => {
@@ -24,10 +150,11 @@ export const getCountdownParts = (diff) => {
   };
 };
 
-export const getCountdownSnapshot = (nowTime = Date.now()) => {
-  const now = new Date(nowTime);
-  const target = getCountdownTarget(now);
-  const diff = clampCountdownDiff(target.getTime(), nowTime);
+export const getCountdownSnapshot = (nowTime = Date.now(), timezone = SYSTEM_TIMEZONE) => {
+  const resolvedNowTime = getNowTimeValue(nowTime);
+  const now = new Date(resolvedNowTime);
+  const target = getCountdownTarget(resolvedNowTime, timezone);
+  const diff = clampCountdownDiff(target.getTime(), resolvedNowTime);
 
   return {
     now,
@@ -37,12 +164,13 @@ export const getCountdownSnapshot = (nowTime = Date.now()) => {
   };
 };
 
-export const getYearProgress = (nowTime = Date.now()) => {
-  const now = new Date(nowTime);
-  const year = now.getFullYear();
-  const start = new Date(year, 0, 1, 0, 0, 0, 0);
-  const end = new Date(year + 1, 0, 1, 0, 0, 0, 0);
-  const elapsedMs = Math.max(0, now.getTime() - start.getTime());
+export const getYearProgress = (nowTime = Date.now(), timezone = SYSTEM_TIMEZONE) => {
+  const resolvedNowTime = getNowTimeValue(nowTime);
+  const timezoneOffsetMinutes = getResolvedTimezoneOffsetMinutes(timezone);
+  const year = getClockYear(resolvedNowTime, timezoneOffsetMinutes);
+  const start = getYearBoundary(year, timezoneOffsetMinutes);
+  const end = getYearBoundary(year + 1, timezoneOffsetMinutes);
+  const elapsedMs = Math.max(0, Math.min(end.getTime() - start.getTime(), resolvedNowTime - start.getTime()));
   const totalMs = end.getTime() - start.getTime();
   const percentage = totalMs === 0 ? 0 : (elapsedMs / totalMs) * 100;
 
@@ -56,13 +184,14 @@ export const getYearProgress = (nowTime = Date.now()) => {
   };
 };
 
-export const getYearMeta = (nowTime = Date.now()) => {
-  const now = new Date(nowTime);
-  const year = now.getFullYear();
-  const startOfYear = new Date(year, 0, 1);
-  const isLeapYear = (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
-  const totalDays = isLeapYear ? 366 : 365;
-  const currentDayIndex = Math.floor((now.getTime() - startOfYear.getTime()) / DAY);
+export const getYearMeta = (nowTime = Date.now(), timezone = SYSTEM_TIMEZONE) => {
+  const resolvedNowTime = getNowTimeValue(nowTime);
+  const { start, end } = getYearProgress(resolvedNowTime, timezone);
+  const totalDays = Math.round((end.getTime() - start.getTime()) / DAY);
+  const currentDayIndex = Math.max(
+    0,
+    Math.min(totalDays - 1, Math.floor((resolvedNowTime - start.getTime()) / DAY)),
+  );
 
   return {
     totalDays,

--- a/src/lib/viewSettings.js
+++ b/src/lib/viewSettings.js
@@ -1,12 +1,25 @@
 import { NAV_LINKS } from './navigation';
 import { THEMES, resolveTheme } from './theme';
-import { getYearMeta } from './timeMath';
+import {
+  INVALID_TIMEZONE_FALLBACK,
+  SYSTEM_TIMEZONE,
+  getYearMeta,
+  normalizeTimezoneSetting,
+} from './timeMath';
 import {
   VIEW_BRAND_TONE_MODES,
   getDefaultViewColors,
   normalizeViewBrandToneMode,
   resolveViewColors,
 } from './viewColors';
+
+const TIMEZONE_CONTROL = {
+  key: 'timezone',
+  type: 'text',
+  label: 'Timezone',
+  placeholder: 'System or UTC+0',
+  hint: 'UTC+4',
+};
 
 export const VIEW_SETTINGS_CONFIG = {
   countdown: {
@@ -25,6 +38,7 @@ export const VIEW_SETTINGS_CONFIG = {
           { label: 'Seconds', value: 'seconds' },
         ],
       },
+      TIMEZONE_CONTROL,
       {
         key: 'frame',
         type: 'boolean',
@@ -71,6 +85,7 @@ export const VIEW_SETTINGS_CONFIG = {
           { label: 'Triangle', value: 'triangle' },
         ],
       },
+      TIMEZONE_CONTROL,
       {
         key: 'triangleMode',
         type: 'select',
@@ -144,6 +159,7 @@ export const VIEW_SETTINGS_CONFIG = {
           { label: 'Rectangle', value: 'rectangle' },
         ],
       },
+      TIMEZONE_CONTROL,
       {
         key: 'style',
         type: 'select',
@@ -190,6 +206,7 @@ export const VIEW_SETTINGS_CONFIG = {
           { label: 'Line', value: 'line' },
         ],
       },
+      TIMEZONE_CONTROL,
       {
         key: 'fullScreen',
         type: 'boolean',
@@ -246,6 +263,7 @@ export const VIEW_SETTINGS_CONFIG = {
           { label: 'Custom', value: 'custom' },
         ],
       },
+      TIMEZONE_CONTROL,
       {
         key: 'dotsCount',
         type: 'number',
@@ -491,6 +509,9 @@ export const getSharedViewUrl = ({ pathname, origin, theme, viewId, viewState, c
     if (viewState.mode !== COUNTDOWN_DEFAULT_SETTINGS.mode) {
       params.set('mode', viewState.mode);
     }
+    if (viewState.timezone !== COUNTDOWN_DEFAULT_SETTINGS.timezone) {
+      params.set('timezone', viewState.timezone);
+    }
     if (viewState.frame !== COUNTDOWN_DEFAULT_SETTINGS.frame) {
       params.set('frame', String(viewState.frame));
     }
@@ -517,6 +538,9 @@ export const getSharedViewUrl = ({ pathname, origin, theme, viewId, viewState, c
   if (viewId === 'dots' && viewState) {
     if (viewState.shape !== DOTS_DEFAULT_SETTINGS.shape) {
       params.set('shape', viewState.shape);
+    }
+    if (viewState.timezone !== DOTS_DEFAULT_SETTINGS.timezone) {
+      params.set('timezone', viewState.timezone);
     }
     if (viewState.triangleMode !== DOTS_DEFAULT_SETTINGS.triangleMode) {
       params.set('triangleMode', viewState.triangleMode);
@@ -551,6 +575,9 @@ export const getSharedViewUrl = ({ pathname, origin, theme, viewId, viewState, c
     if (viewState.shape !== PIE_DEFAULT_SETTINGS.shape) {
       params.set('shape', viewState.shape);
     }
+    if (viewState.timezone !== PIE_DEFAULT_SETTINGS.timezone) {
+      params.set('timezone', viewState.timezone);
+    }
     if (viewState.style !== PIE_DEFAULT_SETTINGS.style) {
       params.set('style', viewState.style);
     }
@@ -577,6 +604,9 @@ export const getSharedViewUrl = ({ pathname, origin, theme, viewId, viewState, c
   if (viewId === 'progress' && viewState) {
     if (viewState.mode !== PROGRESS_DEFAULT_SETTINGS.mode) {
       params.set('mode', viewState.mode);
+    }
+    if (viewState.timezone !== PROGRESS_DEFAULT_SETTINGS.timezone) {
+      params.set('timezone', viewState.timezone);
     }
     if (viewState.fullScreen !== PROGRESS_DEFAULT_SETTINGS.fullScreen) {
       params.set('fullScreen', String(viewState.fullScreen));
@@ -607,6 +637,9 @@ export const getSharedViewUrl = ({ pathname, origin, theme, viewId, viewState, c
   if (viewId === 'all' && viewState) {
     if (viewState.dotsMode !== ALL_DEFAULT_SETTINGS.dotsMode) {
       params.set('dotsMode', viewState.dotsMode);
+    }
+    if (viewState.timezone !== ALL_DEFAULT_SETTINGS.timezone) {
+      params.set('timezone', viewState.timezone);
     }
     if (viewState.dotsMode === 'custom' && viewState.dotsCount !== ALL_DEFAULT_SETTINGS.dotsCount) {
       params.set('dotsCount', String(viewState.dotsCount));
@@ -701,6 +734,7 @@ export const getSharedViewUrl = ({ pathname, origin, theme, viewId, viewState, c
 
 export const COUNTDOWN_DEFAULT_SETTINGS = {
   mode: 'all',
+  timezone: SYSTEM_TIMEZONE,
   frame: false,
   labels: true,
   fontSize: 1,
@@ -712,6 +746,7 @@ export const COUNTDOWN_DEFAULT_SETTINGS = {
 
 export const DOTS_DEFAULT_SETTINGS = {
   shape: 'circle',
+  timezone: SYSTEM_TIMEZONE,
   triangleMode: 'upright',
   triangleAngle: 0,
   gapX: 0.5,
@@ -725,6 +760,7 @@ export const DOTS_DEFAULT_SETTINGS = {
 
 export const PIE_DEFAULT_SETTINGS = {
   shape: 'circle',
+  timezone: SYSTEM_TIMEZONE,
   style: 'filled',
   fullScreen: false,
   decimals: 2,
@@ -736,6 +772,7 @@ export const PIE_DEFAULT_SETTINGS = {
 
 export const PROGRESS_DEFAULT_SETTINGS = {
   mode: 'field',
+  timezone: SYSTEM_TIMEZONE,
   fullScreen: true,
   decimals: 2,
   fontSize: 1,
@@ -749,6 +786,7 @@ export const PROGRESS_DEFAULT_SETTINGS = {
 export const ALL_DEFAULT_SETTINGS = {
   dotsMode: 'days',
   dotsCount: 365,
+  timezone: SYSTEM_TIMEZONE,
   showDays: true,
   showPercentBox: true,
   showPerimeter: true,
@@ -797,6 +835,25 @@ const clampNumber = (value, min, max, fallback) => {
   }
 
   return Math.min(max, Math.max(min, parsed));
+};
+
+const normalizeTimezonePreference = (value, fallback = SYSTEM_TIMEZONE) => {
+  if (value === undefined || value === null) {
+    return fallback;
+  }
+
+  if (typeof value === 'string' && !value.trim()) {
+    return fallback;
+  }
+
+  return normalizeTimezoneSetting(value, INVALID_TIMEZONE_FALLBACK);
+};
+
+const getResolvedTimezoneSetting = (searchParams, persistedSettings, defaults) => {
+  return normalizeTimezonePreference(
+    searchParams.get('timezone') ?? persistedSettings.timezone,
+    defaults.timezone,
+  );
 };
 
 const getResolvedColorSettings = (searchParams, theme, fallbackColors) => {
@@ -881,6 +938,8 @@ export const normalizeCountdownSettingValue = (key, value, theme) => {
   switch (key) {
     case 'mode':
       return ['all', 'days', 'hours', 'minutes', 'seconds'].includes(value) ? value : COUNTDOWN_DEFAULT_SETTINGS.mode;
+    case 'timezone':
+      return normalizeTimezonePreference(value, COUNTDOWN_DEFAULT_SETTINGS.timezone);
     case 'frame':
     case 'labels':
       return value === true || value === 'true';
@@ -903,6 +962,8 @@ export const normalizeDotsSettingValue = (key, value) => {
   switch (key) {
     case 'shape':
       return ['circle', 'square', 'triangle'].includes(value) ? value : DOTS_DEFAULT_SETTINGS.shape;
+    case 'timezone':
+      return normalizeTimezonePreference(value, DOTS_DEFAULT_SETTINGS.timezone);
     case 'triangleMode':
       return ['upright', 'inverted', 'alternating', 'angle'].includes(value)
         ? value
@@ -938,6 +999,8 @@ export const normalizePieSettingValue = (key, value) => {
   switch (key) {
     case 'shape':
       return ['circle', 'rectangle'].includes(value) ? value : PIE_DEFAULT_SETTINGS.shape;
+    case 'timezone':
+      return normalizeTimezonePreference(value, PIE_DEFAULT_SETTINGS.timezone);
     case 'style':
       return ['filled', 'outline'].includes(value) ? value : PIE_DEFAULT_SETTINGS.style;
     case 'fullScreen':
@@ -966,6 +1029,8 @@ export const normalizeProgressSettingValue = (key, value) => {
   switch (key) {
     case 'mode':
       return ['field', 'line'].includes(value) ? value : PROGRESS_DEFAULT_SETTINGS.mode;
+    case 'timezone':
+      return normalizeTimezonePreference(value, PROGRESS_DEFAULT_SETTINGS.timezone);
     case 'fullScreen':
       return value === true || value === 'true';
     case 'decimals':
@@ -996,6 +1061,8 @@ export const normalizeAllSettingValue = (key, value) => {
   switch (key) {
     case 'dotsMode':
       return ['days', 'custom'].includes(value) ? value : ALL_DEFAULT_SETTINGS.dotsMode;
+    case 'timezone':
+      return normalizeTimezonePreference(value, ALL_DEFAULT_SETTINGS.timezone);
     case 'dotsCount':
       return clampNumber(value, 1, 2000, ALL_DEFAULT_SETTINGS.dotsCount);
     case 'showDays':
@@ -1062,11 +1129,13 @@ export const getCountdownSettingsFromSearchParams = (searchParams, theme, persis
   const labels = searchParams.get('labels') ?? persistedSettings.labels;
   const colors = getResolvedColorSettings(searchParams, theme, fallbackColors);
   const spacing = getLegacySideSpacing(searchParams, persistedSettings, COUNTDOWN_DEFAULT_SETTINGS);
+  const timezone = getResolvedTimezoneSetting(searchParams, persistedSettings, COUNTDOWN_DEFAULT_SETTINGS);
 
   return {
     mode: ['all', 'days', 'hours', 'minutes', 'seconds'].includes(mode)
       ? mode
       : COUNTDOWN_DEFAULT_SETTINGS.mode,
+    timezone,
     frame:
       frame === 'true' || frame === true
         ? true
@@ -1096,9 +1165,11 @@ export const getDotsSettingsFromSearchParams = (searchParams, theme, persistedSe
   const legacyGap = searchParams.get('gap');
   const colors = getResolvedColorSettings(searchParams, theme, fallbackColors);
   const spacing = getLegacySideSpacing(searchParams, persistedSettings, DOTS_DEFAULT_SETTINGS);
+  const timezone = getResolvedTimezoneSetting(searchParams, persistedSettings, DOTS_DEFAULT_SETTINGS);
 
   return {
     shape: ['circle', 'square', 'triangle'].includes(shape) ? shape : DOTS_DEFAULT_SETTINGS.shape,
+    timezone,
     triangleMode: ['upright', 'inverted', 'alternating', 'angle'].includes(triangleMode)
       ? triangleMode
       : DOTS_DEFAULT_SETTINGS.triangleMode,
@@ -1137,9 +1208,11 @@ export const getPieSettingsFromSearchParams = (searchParams, theme, persistedSet
   const fullScreen = searchParams.get('fullScreen') ?? persistedSettings.fullScreen;
   const colors = getResolvedColorSettings(searchParams, theme, fallbackColors);
   const spacing = getLegacySideSpacing(searchParams, persistedSettings, PIE_DEFAULT_SETTINGS);
+  const timezone = getResolvedTimezoneSetting(searchParams, persistedSettings, PIE_DEFAULT_SETTINGS);
 
   return {
     shape: ['circle', 'rectangle'].includes(shape) ? shape : PIE_DEFAULT_SETTINGS.shape,
+    timezone,
     style: ['filled', 'outline'].includes(style) ? style : PIE_DEFAULT_SETTINGS.style,
     fullScreen:
       fullScreen === 'true' || fullScreen === true
@@ -1163,9 +1236,11 @@ export const getProgressSettingsFromSearchParams = (searchParams, theme, persist
   const fullScreen = searchParams.get('fullScreen') ?? persistedSettings.fullScreen;
   const colors = getResolvedColorSettings(searchParams, theme, fallbackColors);
   const spacing = getLegacySideSpacing(searchParams, persistedSettings, PROGRESS_DEFAULT_SETTINGS);
+  const timezone = getResolvedTimezoneSetting(searchParams, persistedSettings, PROGRESS_DEFAULT_SETTINGS);
 
   return {
     mode: ['field', 'line'].includes(mode) ? mode : PROGRESS_DEFAULT_SETTINGS.mode,
+    timezone,
     fullScreen:
       fullScreen === 'true' || fullScreen === true
         ? true
@@ -1201,7 +1276,8 @@ export const getAllSettingsFromSearchParams = (searchParams, theme, persistedSet
   const legacyGap = searchParams.get('gap');
   const colors = getResolvedColorSettings(searchParams, theme, fallbackColors);
   const spacing = getLegacySideSpacing(searchParams, persistedSettings, ALL_DEFAULT_SETTINGS);
-  const { totalDays } = getYearMeta();
+  const timezone = getResolvedTimezoneSetting(searchParams, persistedSettings, ALL_DEFAULT_SETTINGS);
+  const { totalDays } = getYearMeta(Date.now(), timezone);
   const defaultDotsCount = dotsMode === 'custom' ? ALL_DEFAULT_SETTINGS.dotsCount : totalDays;
 
   return {
@@ -1212,6 +1288,7 @@ export const getAllSettingsFromSearchParams = (searchParams, theme, persistedSet
       2000,
       defaultDotsCount,
     ),
+    timezone,
     showDays:
       searchParams.get('showDays') === 'true' || persistedSettings.showDays === true
         ? true

--- a/src/pages/SamplesPage.jsx
+++ b/src/pages/SamplesPage.jsx
@@ -154,6 +154,7 @@ const renderSampleView = ({ viewId, viewState, textTone }) => {
         mode={viewState.mode}
         frame={viewState.frame}
         labels={viewState.labels}
+        timezone={viewState.timezone}
         fontSize={viewState.fontSize}
         spaceTop={viewState.spaceTop}
         spaceRight={viewState.spaceRight}
@@ -172,6 +173,7 @@ const renderSampleView = ({ viewId, viewState, textTone }) => {
         shape={viewState.shape}
         triangleMode={viewState.triangleMode}
         triangleAngle={viewState.triangleAngle}
+        timezone={viewState.timezone}
         gapX={viewState.gapX}
         gapY={viewState.gapY}
         inactiveOpacity={viewState.inactiveOpacity}
@@ -192,6 +194,7 @@ const renderSampleView = ({ viewId, viewState, textTone }) => {
         style={viewState.style}
         fullScreen={viewState.fullScreen}
         decimals={viewState.decimals}
+        timezone={viewState.timezone}
         spaceTop={viewState.spaceTop}
         spaceRight={viewState.spaceRight}
         spaceBottom={viewState.spaceBottom}
@@ -209,6 +212,7 @@ const renderSampleView = ({ viewId, viewState, textTone }) => {
         mode={viewState.mode}
         fullScreen={viewState.fullScreen}
         decimals={viewState.decimals}
+        timezone={viewState.timezone}
         fontSize={viewState.fontSize}
         lineWidth={viewState.lineWidth}
         spaceTop={viewState.spaceTop}
@@ -229,6 +233,7 @@ const renderSampleView = ({ viewId, viewState, textTone }) => {
       showDays={viewState.showDays}
       showPercentBox={viewState.showPercentBox}
       showPerimeter={viewState.showPerimeter}
+      timezone={viewState.timezone}
       shape={viewState.shape}
       triangleMode={viewState.triangleMode}
       triangleAngle={viewState.triangleAngle}

--- a/src/pages/views/AllPage.jsx
+++ b/src/pages/views/AllPage.jsx
@@ -13,6 +13,7 @@ const AllPage = () => {
         showDays={viewState.all.showDays}
         showPercentBox={viewState.all.showPercentBox}
         showPerimeter={viewState.all.showPerimeter}
+        timezone={viewState.all.timezone}
         shape={viewState.all.shape}
         triangleMode={viewState.all.triangleMode}
         triangleAngle={viewState.all.triangleAngle}

--- a/src/pages/views/CountdownPage.jsx
+++ b/src/pages/views/CountdownPage.jsx
@@ -12,6 +12,7 @@ const CountdownPage = () => {
         mode={viewState.countdown.mode}
         frame={viewState.countdown.frame}
         labels={viewState.countdown.labels}
+        timezone={viewState.countdown.timezone}
         fontSize={viewState.countdown.fontSize}
         spaceTop={viewState.countdown.spaceTop}
         spaceRight={viewState.countdown.spaceRight}

--- a/src/pages/views/DotsPage.jsx
+++ b/src/pages/views/DotsPage.jsx
@@ -11,6 +11,7 @@ const DotsPage = () => {
         shape={viewState.dots.shape}
         triangleMode={viewState.dots.triangleMode}
         triangleAngle={viewState.dots.triangleAngle}
+        timezone={viewState.dots.timezone}
         gapX={viewState.dots.gapX}
         gapY={viewState.dots.gapY}
         inactiveOpacity={viewState.dots.inactiveOpacity}

--- a/src/pages/views/PiePage.jsx
+++ b/src/pages/views/PiePage.jsx
@@ -20,6 +20,7 @@ const PiePage = () => {
         style={style}
         fullScreen={fullScreen}
         decimals={decimals}
+        timezone={viewState.pie.timezone}
         spaceTop={spaceTop}
         spaceRight={spaceRight}
         spaceBottom={spaceBottom}

--- a/src/pages/views/ProgressPage.jsx
+++ b/src/pages/views/ProgressPage.jsx
@@ -19,6 +19,7 @@ const ProgressPage = () => {
         mode={mode}
         fullScreen={fullScreen}
         decimals={decimals}
+        timezone={viewState.progress.timezone}
         fontSize={fontSize}
         lineWidth={lineWidth}
         spaceTop={spaceTop}


### PR DESCRIPTION
Closes #5

## Summary

This PR fixes wallpaper rendering so generated wallpapers use the user-configured timezone instead of the server/runtime timezone.

Previously, time-based views depended on the environment time where the page was rendered, which caused third-party wallpaper generation to capture the wrong countdown/progress for users in other timezones.

## What changed

- Added a `timezone` view setting for all time-based views
- Added timezone parsing/normalization for values like:
  - `UTC+0`
  - `UTC+4`
  - `UTC-8`
  - `UTC+5:30`
- Updated countdown, year progress, and dots/day calculations to use the configured UTC offset when provided
- Included `timezone` in shared embed URLs and wallpaper URLs
- Added a timezone input in the settings gear so the rendered page and exported wallpaper stay in sync
- Kept existing behavior unchanged when no timezone is set
- Added fallback handling for invalid timezone values (`UTC+0`)
- Updated docs to describe the new `timezone` property and accepted format

## Result

Wallpapers now match the same timezone-adjusted time shown in the view, regardless of where the image generator is running.

## Testing

- Verified timezone-aware countdown/progress behavior around year-boundary cases
- Ran `npm run build` successfully

## Notes

- Leaving `timezone` blank keeps the current system/runtime time behavior
- Invalid timezone input falls back to `UTC+0`
